### PR TITLE
feat: ports are configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,26 @@ All customization options (use with caution):
 | ------------------------------ | -------------------------------- | ---------------------------- |
 | `OPENAI_EDGE_TTS_DOCKER_IMAGE` | `--openai-edge-tts-docker-image` | `ddev/ddev-utilities:latest` |
 
+### Ports
+
+To change the HTTP/S ports exposed to the host system:
+
+- Use DDEV dotenv command
+
+    ```shell
+    ddev dotenv set .ddev/.env --tts-http-port="${TTS_HTTP_PORT}"   # HTTP
+    ddev dotenv set .ddev/.env --tts-https-port="${TTS_HTTPS_PORT}" # HTTPS
+    ```
+
+- or, update the `.ddev/.env` file directly.
+
+    ```env
+    TTS_HTTP_PORT=5010
+    TTS_HTTPS_PORT=5011
+    ```
+
+Restart DDEV to apply the changes.
+
 ## Credits
 
 **Contributed and maintained by [@tyler36](https://github.com/tyler36)**

--- a/docker-compose.openai-edge-tts.yaml
+++ b/docker-compose.openai-edge-tts.yaml
@@ -8,8 +8,8 @@ services:
       - ddev-global-cache:/mnt/ddev-global-cache
     environment:
       - VIRTUAL_HOST=$DDEV_HOSTNAME
-      - HTTP_EXPOSE=5049:5050
-      - HTTPS_EXPOSE=5050:5050
+      - HTTP_EXPOSE=${TTS_HTTP_PORT:-5049}:5050
+      - HTTPS_EXPOSE=${TTS_HTTPS_PORT:-5050}:5050
     restart: "no"
     # These labels ensure this service is discoverable by DDEV.
     labels:


### PR DESCRIPTION
## The Issue

Ports are currently hard-coded. We can do better and allow developers to configure them, if required.

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

Read `TTS_HTTP_PORT` and `TTS_HTTPS_PORT` from the environment and apply.

## Manual Testing Instructions

1. Install addon
2. Configure ports

    ```shell
    ddev dotenv set .ddev/.env --tts-http-port="${TTS_HTTP_PORT}"   # HTTP
    ddev dotenv set .ddev/.env --tts-https-port="${TTS_HTTPS_PORT}" # HTTPS
    ```

1. Send a request to the new endpoint ("https://${PROJNAME}.ddev.site:${TTS_HTTP_PORT}/v1/audio/speech") to confirm it works.

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/tyler36/ddev-openai-edge-tts/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
ddev restart
```

## Automated Testing Overview

Automated tests provided.

```shell
bats ./tests/test.bats -f "API ports are configurable"
```

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
